### PR TITLE
Fix footnote popup position

### DIFF
--- a/src/components/EmailMainContent.tsx
+++ b/src/components/EmailMainContent.tsx
@@ -186,11 +186,11 @@ const EmailMainContent: React.FC<EmailMainContentProps> = ({
                     onClose={handlePopoverClose}
                     anchorOrigin={{
                         vertical: 'bottom',
-                        horizontal: 'center',
+                        horizontal: 'left',
                     }}
                     transformOrigin={{
                         vertical: 'top',
-                        horizontal: 'center',
+                        horizontal: 'left',
                     }}
                     PaperProps={{
                         sx: {


### PR DESCRIPTION
The popup was appearing at the top left of the screen, far from the footnote link.

This change adjusts the `anchorOrigin` and `transformOrigin` of the `Popover` component to correctly position the popup under the footnote link.