### PR TITLE
feat: Increase footnote width to at least 70% of screen width

### DIFF
--- a/src/components/EmailMainContent.tsx
+++ b/src/components/EmailMainContent.tsx
@@ -195,15 +195,12 @@ const EmailMainContent: React.FC<EmailMainContentProps> = ({
                     PaperProps={{
                         sx: {
                             p: 2,
-                            maxWidth: 350,
                             border: '1px solid',
                             borderColor: 'primary.main',
                             boxShadow: 3,
+                            minWidth: '70vw',
+                            maxWidth: '90vw',
                         }
-                    }}
-                    style={{
-                        top: popoverAnchorEl ? `${popoverAnchorEl.getBoundingClientRect().bottom + window.scrollY}px` : 'auto',
-                        left: popoverAnchorEl ? `${popoverAnchorEl.getBoundingClientRect().left + window.scrollX}px` : 'auto',
                     }}
                 >
                     <Typography variant="subtitle2" sx={{ fontWeight: 'bold', color: 'primary.main', mb: 1 }}>


### PR DESCRIPTION
The footnote popover was previously limited to a max-width of 350px, which could be too narrow on larger screens.

This change adjusts the styling of the footnote Popover component to have a min-width of 70vw and a max-width of 90vw. This ensures that the footnote is always readable and takes up a reasonable amount of screen space.

The inline style for positioning the popover was also removed, as it is not needed and Material-UI can handle the positioning automatically.